### PR TITLE
chore: narrow react hooks lint suppression

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,8 @@ export default function App(){
   const [autoSeed,setAutoSeed]=useState<boolean>(()=>load(STORAGE_AUTOSEED_KEY,true));
   const [baseTemplate,setBaseTemplate]=useState<WeekData>(()=>load(STORAGE_TEMPLATE_KEY,makeDefaultTemplate()));
 
-  useEffect(()=>{ const wkKey=fmtISO(weekStart); if(!data[wkKey]){ const seeded=autoSeed?JSON.parse(JSON.stringify(baseTemplate)):makeEmptyWeek(); setData(prev=>({...prev,[wkKey]:seeded})); }},[weekStart]); // eslint-disable-line
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- only seed when the week changes
+  useEffect(()=>{ const wkKey=fmtISO(weekStart); if(!data[wkKey]){ const seeded=autoSeed?JSON.parse(JSON.stringify(baseTemplate)):makeEmptyWeek(); setData(prev=>({...prev,[wkKey]:seeded})); }},[weekStart]);
   useEffect(()=>save(STORAGE_KEY,data),[data]);
   useEffect(()=>save(STORAGE_TEMPLATE_KEY,baseTemplate),[baseTemplate]);
   useEffect(()=>save(STORAGE_AUTOSEED_KEY,autoSeed),[autoSeed]);


### PR DESCRIPTION
## Summary
- replace broad `eslint-disable-line` with targeted `react-hooks/exhaustive-deps` directive in useEffect seeding logic

## Testing
- `npx eslint src/App.tsx --parser @typescript-eslint/parser --plugin react-hooks --rule 'react-hooks/exhaustive-deps: error'` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npx --yes -p @typescript-eslint/parser -p eslint-plugin-react-hooks -p eslint eslint src/App.tsx --parser @typescript-eslint/parser --plugin react-hooks --rule 'react-hooks/exhaustive-deps: error'` *(fails: 403 Forbidden fetching @typescript-eslint/parser)*

------
https://chatgpt.com/codex/tasks/task_e_689c6912ea78832da44174413de7848e