### PR TITLE
test: add startOfWeek tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d dist",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -19,6 +20,7 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.5.3",
-    "vite": "^5.3.3"
+    "vite": "^5.3.3",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
 const DAY_NAMES = ["SUN","MON","TUE","WED","THU","FRI","SAT"];
-function startOfWeek(date: Date){ const d=new Date(date); const day=d.getDay(); const diff=d.getDate()-day; const out=new Date(d.setDate(diff)); out.setHours(0,0,0,0); return out; }
+export function startOfWeek(date: Date){ const d=new Date(date); const day=d.getDay(); const diff=d.getDate()-day; const out=new Date(d.setDate(diff)); out.setHours(0,0,0,0); return out; }
 function fmtISO(d: Date){ return d.toISOString().slice(0,10); }
 function addDays(d: Date, n: number){ const x=new Date(d); x.setDate(x.getDate()+n); return x; }
 

--- a/src/startOfWeek.test.ts
+++ b/src/startOfWeek.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { startOfWeek } from './App';
+
+describe('startOfWeek', () => {
+  it('returns Sunday of the same week for any given day', () => {
+    const expected = new Date(2024, 4, 12); // Sunday, May 12, 2024
+    expected.setHours(0, 0, 0, 0);
+    const dates = [
+      new Date(2024, 4, 12), // Sunday
+      new Date(2024, 4, 13), // Monday
+      new Date(2024, 4, 14), // Tuesday
+      new Date(2024, 4, 15), // Wednesday
+      new Date(2024, 4, 16), // Thursday
+      new Date(2024, 4, 17), // Friday
+      new Date(2024, 4, 18), // Saturday
+    ];
+    for (const d of dates) {
+      const result = startOfWeek(d);
+      expect(result).toEqual(expected);
+    }
+  });
+
+  it('returns a Date at midnight', () => {
+    const result = startOfWeek(new Date(2024, 4, 15, 15, 30));
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- export `startOfWeek` for external use
- add vitest and basic `startOfWeek` tests

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c69119dd4832d8132168aee06a9cb